### PR TITLE
Use bytes.Buffer instead channels and goroutines

### DIFF
--- a/argument_test.go
+++ b/argument_test.go
@@ -1,6 +1,7 @@
 package graphb
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,32 +70,25 @@ func TestArgumentStringSlice(t *testing.T) {
 func Test_argBool(t *testing.T) {
 	b := argBool(true)
 	i := 0
-	for str := range b.stringChan() {
-		assert.Equal(t, "true", str)
-		i++
-	}
+	var buf bytes.Buffer
+	b.stringChan(&buf)
+	assert.Equal(t, "true", buf.String())
+	i++
 	assert.Equal(t, 1, i)
 }
 
 func Test_argBoolSlice(t *testing.T) {
 	bs := argBoolSlice([]bool{true, false})
-	c := bs.stringChan()
-	i := 0
-	tokens := []string{"[", "true", ",", "false", "]"}
-	for str, ok := <-c; ok; str, ok = <-c {
-		assert.Equal(t, tokens[i], str)
-		i++
-	}
-	assert.Equal(t, len(tokens), i)
+	var buf bytes.Buffer
+	bs.stringChan(&buf)
+	tokens := "[true,false]"
+	assert.Equal(t, tokens, buf.String())
 }
 
 func Test_argIntSlice(t *testing.T) {
 	is := argIntSlice([]int{1, -1, 0})
-	tokens := []string{"[", "1", ",", "-1", ",", "0", "]"}
-	i := 0
-	for str := range is.stringChan() {
-		assert.Equal(t, tokens[i], str)
-		i++
-	}
-	assert.Equal(t, len(tokens), i)
+	tokens := "[1,-1,0]"
+	var buf bytes.Buffer
+	is.stringChan(&buf)
+	assert.Equal(t, tokens, buf.String())
 }

--- a/error.go
+++ b/error.go
@@ -13,7 +13,8 @@ const (
 	argumentName  nameType = "argument name"
 )
 
-// InvalidNameErr is returned when an invalid name is used. In GraphQL, operation, alias, field and argument all have names.
+// InvalidNameErr is returned when an invalid name is used.
+// In GraphQL, operation, alias, field and argument all have names.
 // A valid name matches ^[_A-Za-z][_0-9A-Za-z]*$ exactly.
 type InvalidNameErr struct {
 	Type nameType

--- a/field.go
+++ b/field.go
@@ -1,6 +1,8 @@
 package graphb
 
 import (
+	"bytes"
+
 	"github.com/pkg/errors"
 )
 
@@ -22,66 +24,54 @@ func (f *Field) setFields(fs []*Field) {
 	f.Fields = fs
 }
 
-// StringChan returns read only string token channel or an error.
+// String returns read only string token channel or an error.
 // It checks if there is a circle.
-func (f *Field) StringChan() (<-chan string, error) {
+func (f *Field) StringChan(buffer *bytes.Buffer) error {
 	// todo: new style error handling
 	if err := f.check(); err != nil {
 		// return a closed channel instead of nil for receiving from nil blocks forever, hard to debug and confusing to users.
-		ch := make(chan string)
-		close(ch)
-		return ch, errors.WithStack(err)
+		return errors.WithStack(err)
 	}
-	return f.stringChan(), nil
+	f.stringChan(buffer)
+	return nil
 }
 
-// One may have noticed that there is a public StringChan and a private stringChan.
+// One may have noticed that there is a public String and a private stringChan.
 // The different being the public method checks the validity of the Field structure
 // while the private counterpart assumes the validity.
-func (f *Field) stringChan() <-chan string {
+func (f *Field) stringChan(buffer *bytes.Buffer) {
+	// emit alias and names
+	if f.Alias != "" {
+		buffer.WriteString(f.Alias)
+		buffer.WriteString(tokenColumn)
+	}
+	buffer.WriteString(f.Name)
 
-	tokenChan := make(chan string)
-
-	go func() {
-		// emit alias and names
-		if f.Alias != "" {
-			tokenChan <- f.Alias
-			tokenChan <- tokenColumn
+	// emit argument tokens
+	if len(f.Arguments) > 0 {
+		buffer.WriteString(tokenLP)
+		for i := range f.Arguments {
+			if i != 0 {
+				buffer.WriteString(tokenComma)
+			}
+			f.Arguments[i].stringChan(buffer)
 		}
-		tokenChan <- f.Name
+		buffer.WriteString(tokenRP)
+	}
 
-		// emit argument tokens
-		if len(f.Arguments) > 0 {
-			tokenChan <- tokenLP
-			for i := range f.Arguments {
+	// emit field tokens
+	if len(f.Fields) > 0 {
+		buffer.WriteString(tokenLB)
+		for i, field := range f.Fields {
+			if field != nil {
 				if i != 0 {
-					tokenChan <- tokenComma
+					buffer.WriteString(tokenComma)
 				}
-				for str := range f.Arguments[i].stringChan() {
-					tokenChan <- str
-				}
+				field.stringChan(buffer)
 			}
-			tokenChan <- tokenRP
 		}
-
-		// emit field tokens
-		if len(f.Fields) > 0 {
-			tokenChan <- tokenLB
-			for i, field := range f.Fields {
-				if field != nil {
-					if i != 0 {
-						tokenChan <- tokenComma
-					}
-					for str := range field.stringChan() {
-						tokenChan <- str
-					}
-				}
-			}
-			tokenChan <- tokenRB
-		}
-		close(tokenChan)
-	}()
-	return tokenChan
+		buffer.WriteString(tokenRB)
+	}
 }
 
 func (f *Field) check() error {
@@ -133,9 +123,9 @@ func (f *Field) checkCycle() error {
 	return nil
 }
 
-////////////////
+// //////////////
 // Public API //
-////////////////
+// //////////////
 
 // MakeField constructs a Field of given name and return the pointer to this Field.
 func MakeField(name string) *Field {
@@ -165,9 +155,9 @@ func (f *Field) SetAlias(alias string) *Field {
 	return f
 }
 
-/////////////
+// ///////////
 // Helpers //
-/////////////
+// ///////////
 // reach checks if f1 can be reached by f2 either directly (itself) or indirectly (children)
 func reach(f1, f2 *Field) error {
 	if f1 == nil || f2 == nil {

--- a/public.go
+++ b/public.go
@@ -4,19 +4,8 @@
 package graphb
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
 )
-
-// StringFromChan builds a string from a channel, assuming the channel has been closed.
-func StringFromChan(c <-chan string) string {
-	var strs []string
-	for str := range c {
-		strs = append(strs, str)
-	}
-	return strings.Join(strs, "")
-}
 
 ///////////////////
 // Field Factory //

--- a/query_test.go
+++ b/query_test.go
@@ -1,7 +1,7 @@
 package graphb
 
 import (
-	"strings"
+	"bytes"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -53,14 +53,10 @@ func TestQuery_JSON(t *testing.T) {
 					),
 			)
 
-		c := q.stringChan()
+		var buf bytes.Buffer
+		q.string(&buf)
 
-		var strs []string
-		for str := range c {
-			strs = append(strs, str)
-		}
-
-		assert.Equal(t, `mutation{createQuestion(input:{title:"what",content:"what",tagIds:[]}){question{id}}}`, strings.Join(strs, ""))
+		assert.Equal(t, `mutation{createQuestion(input:{title:"what",content:"what",tagIds:[]}){question{id}}}`, buf.String())
 	})
 
 }


### PR DESCRIPTION
Hello! :)
Thanks for the library
I made a few changes, namely: I got rid of goroutines and channels, which helped greatly increase performance

BenchmarkMakeQueryOld-4        30000    54336 ns/op   2537 B/op   29 allocs/op
BenchmarkMakeQueryBuffered-4   200000   6547 ns/op    744 B/op    15 allocs/op