### PR TITLE
Add unquoted string / field support for arguments

### DIFF
--- a/argument_test.go
+++ b/argument_test.go
@@ -66,6 +66,21 @@ func TestArgumentStringSlice(t *testing.T) {
 	assert.Equal(t, Argument{"blocked", argStringSlice(nil)}, a)
 }
 
+func TestArgumentField(t *testing.T) {
+	a := ArgumentField("blocked", "a")
+	assert.Equal(t, Argument{"blocked", argField("a")}, a)
+	a = ArgumentField("blocked", "")
+	assert.Equal(t, Argument{"blocked", argField("")}, a)
+}
+
+func TestArgumentFieldSlice(t *testing.T) {
+	a := ArgumentFieldSlice("blocked", "a", "b", "", " ", "d")
+	assert.Equal(t, Argument{"blocked", argFieldSlice([]string{"a", "b", "", " ", "d"})}, a)
+
+	a = ArgumentFieldSlice("blocked")
+	assert.Equal(t, Argument{"blocked", argFieldSlice(nil)}, a)
+}
+
 func Test_argBool(t *testing.T) {
 	b := argBool(true)
 	i := 0

--- a/example/three_ways_to_construct_query_test.go
+++ b/example/three_ways_to_construct_query_test.go
@@ -36,6 +36,7 @@ func TestMethodChaining(t *testing.T) {
 							graphb.ArgumentInt("fizzbuzz", 45),
 						),
 					),
+					graphb.ArgumentField("field", "fizzbuzz"),
 				).
 				SetFields(
 					graphb.MakeField("x").
@@ -50,7 +51,7 @@ func TestMethodChaining(t *testing.T) {
 		AddFields(graphb.MakeField("b"))
 	s, err := q.JSON()
 	assert.Nil(t, err)
-	assert.Equal(t, `{"query":"query{some_alias:a(string:\"123\",mapArray:[{foo:\"bar\",fizzbuzz:15},{foo:\"baz\",fizzbuzz:45}]){x(string:\"123\",int_slice:[1,2,3]),y},b}"}`, s)
+	assert.Equal(t, `{"query":"query{some_alias:a(string:\"123\",mapArray:[{foo:\"bar\",fizzbuzz:15},{foo:\"baz\",fizzbuzz:45}],field:fizzbuzz){x(string:\"123\",int_slice:[1,2,3]),y},b}"}`, s)
 }
 
 func TestFunctionalOptions(t *testing.T) {


### PR DESCRIPTION
Hi!
I didn't find a way to modify a mutation with arguments to reference fields (strings) without quotes.
Use Case:  
https://hasura.io/docs/1.0/graphql/manual/mutations/upsert.html

The "on_conflict" clause requires to pass the fields without quotes. 
```
on_conflict: {
      constraint: article_pkey,
      update_columns: [title, content]
}
```
This pull request is a proposal to add a new ArgumentField, which will take a string and transform it without quotes. In addition, this makes the ArgumentValue interface public in case anyone needs custom transformations for arguments.
I'm open to suggestions on how to improve or change this PR for it to get accepted. 